### PR TITLE
Add vitest and toast reducer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,6 +80,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { reducer } from './use-toast'
+
+describe('toast reducer', () => {
+  it('adds a toast', () => {
+    const initial = { toasts: [] as any[] }
+    const toast = { id: '1', title: 'hi', open: true }
+    const state = reducer(initial, { type: 'ADD_TOAST', toast })
+    expect(state.toasts).toEqual([toast])
+  })
+
+  it('updates a toast', () => {
+    const initial = { toasts: [{ id: '1', title: 'first', open: true }] }
+    const state = reducer(initial, { type: 'UPDATE_TOAST', toast: { id: '1', title: 'updated' } })
+    expect(state.toasts[0]).toMatchObject({ id: '1', title: 'updated', open: true })
+  })
+
+  it('dismisses a toast', () => {
+    const initial = { toasts: [{ id: '1', title: 'x', open: true }] }
+    const state = reducer(initial, { type: 'DISMISS_TOAST', toastId: '1' })
+    expect(state.toasts[0].open).toBe(false)
+  })
+
+  it('removes a toast', () => {
+    const initial = { toasts: [
+      { id: '1', open: false },
+      { id: '2', open: true }
+    ] }
+    const state = reducer(initial, { type: 'REMOVE_TOAST', toastId: '1' })
+    expect(state.toasts).toEqual([{ id: '2', open: true }])
+  })
+})


### PR DESCRIPTION
## Summary
- add `test` script and vitest dev dependency
- add tests for `reducer` logic in `use-toast`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454053c874832eaef2d6dd15d66d73