### PR TITLE
Fix toast removal timing and tests

### DIFF
--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -21,6 +21,17 @@ describe('toast reducer', () => {
     expect(state.toasts[0].open).toBe(false)
   })
 
+  it('dismisses all toasts when id not provided', () => {
+    const initial = {
+      toasts: [
+        { id: '1', open: true },
+        { id: '2', open: true }
+      ]
+    }
+    const state = reducer(initial, { type: 'DISMISS_TOAST' })
+    expect(state.toasts.every(t => !t.open)).toBe(true)
+  })
+
   it('removes a toast', () => {
     const initial = { toasts: [
       { id: '1', open: false },

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,10 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Delay before a dismissed toast is permanently removed
+// from state. One second keeps the UI responsive while
+// allowing any exit animations to play.
+const TOAST_REMOVE_DELAY = 1000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten delay before toast removal
- add test for dismissing all toasts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454836d530832e8d8ffa185be8d7e9